### PR TITLE
ncursesw patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ OBJ = $(SRC:.c=.o)
 
 CC = gcc
 override INCLUDE += .
-LIB = -lncurses #-lefence
-CFLAGS = -O3 -DVERSION=$(VERSION) -Wall -fPIC -Wextra -ansi -pedantic -Wstrict-prototypes -I$(INCLUDE)
+LIB = $(shell pkg-config --libs ncursesw)  #-lefence
+CFLAGS += -O3 -Wall -fPIC -Wextra -pedantic -Wstrict-prototypes -I$(INCLUDE) $(shell pkg-config --cflags ncursesw)
 RM = rm -fr
 LDFLAGS =
 
@@ -37,7 +37,7 @@ $(NAME):	$(OBJ)
 		$(CC) -o $(NAME) $(OBJ) $(LIB) $(LDFLAGS)
 
 lib$(NAME): $(LIB_OBJ)
-		$(CC) --shared -o $(LINKERNAME) $(LIB_OBJ) $(LDFLAGS)
+		$(CC) $(CFLAGS) --shared -o $(LINKERNAME) $(OBJ) $(LIB) $(LDFLAGS)
 
 install:	$(NAME)
 		mkdir -p $(DESTDIR)/usr/bin/

--- a/src/avl.c
+++ b/src/avl.c
@@ -63,7 +63,7 @@ static char *repr(const char *str)
     if (clean == NULL)
         return NULL;
     for (i = 0; clean[i] != '\0'; ++i)
-        if (clean[i] < ' ' || clean[i] > '~')
+        if (clean[i] > 0 && clean[i] < ' ')
             clean[i] = '.';
     return clean;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include <getopt.h>
+#include <locale.h>
 #include "main.h"
 
 env_t gl_env;
@@ -194,6 +195,7 @@ static void on_sigint(int sig)
 
 int main(int ac, char **av)
 {
+    setlocale(LC_ALL, "");
     parse_args(ac, av);
     setup_sighandler(SIGINT, 0, on_sigint);
     setup_sighandler(SIGALRM, SA_RESTART, update_display);


### PR DESCRIPTION
Hi,
I maintain logtop package for openSUSE and got a patch submitted (which I accepted) to use ncursesw instead of old ncurses only. This may imply to drop support for old ncurses releases that have no pkgconfig scripts at all.